### PR TITLE
Added missing attribute definitions for new States

### DIFF
--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -2065,6 +2065,78 @@ const state_attr = {
         iptype: false,
         multiply: 1
     },
+      'BMS.CELL_BALANCE_STATUS': {
+        name: 'CELL_BALANCE_STATUS',
+        unit: '',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    },    
+      'BMS.CELL_TEMPERATURES_MODULE_A': {
+        name: 'CELL_TEMPERATURES_MODULE_A',
+        unit: '°C',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    },  
+      'BMS.CELL_TEMPERATURES_MODULE_B': {
+        name: 'CELL_TEMPERATURES_MODULE_B',
+        unit: '°C',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    }, 
+      'BMS.CELL_TEMPERATURES_MODULE_C': {
+        name: 'CELL_TEMPERATURES_MODULE_C',
+        unit: '°C',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    }, 
+      'BMS.CELL_TEMPERATURES_MODULE_D': {
+        name: 'CELL_TEMPERATURES_MODULE_D',
+        unit: '°C',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    }, 
+      'BMS.CELL_VOLTAGES_MODULE_A': {
+        name: 'CELL_VOLTAGES_MODULE_A',
+        unit: 'mV',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    }, 
+      'BMS.CELL_VOLTAGES_MODULE_B': {
+        name: 'CELL_VOLTAGES_MODULE_V',
+        unit: 'mV',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    }, 
+      'BMS.CELL_VOLTAGES_MODULE_C': {
+        name: 'CELL_VOLTAGES_MODULE_C',
+        unit: 'mV',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    }, 
+      'BMS.CELL_VOLTAGES_MODULE_D': {
+        name: 'CELL_VOLTAGES_MODULE_D',
+        unit: 'mV',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    }, 
     'BMS.BMS_READY_FLAG': {
         name: 'BMS Ready Flag',
         unit: '',
@@ -2347,6 +2419,22 @@ const state_attr = {
     },
     'BMS.START_UPDATE': {
         name: 'Start Update',
+        unit: '',
+        booltype: true,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    },
+    'BMS.BMS_STATUS': {
+        name: 'BMS_Status',
+        unit: '',
+        booltype: true,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    },
+    'BMS.BMS_STATUS_TIMESTAMP': {
+        name: 'BMS_Status_Timestamp',
         unit: '',
         booltype: true,
         datetype: false,
@@ -2993,6 +3081,22 @@ const state_attr = {
         iptype: false,
         multiply: 1
     },
+    'ENERGY.GUI_BAT_DATA_MAX_CELL_VOLTAGE': {
+        name: 'BAT_DATA_MAX_CELL_VOLTAGE',
+        unit: 'mV',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    },
+    'ENERGY.GUI_BAT_DATA_MIN_CELL_VOLTAGE': {
+        name: 'BAT_DATA_MIN_CELL_VOLTAGE',
+        unit: 'mV',
+        booltype: false,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    },
     'ENERGY.GUI_BAT_DATA_OA_CHARGING': {
         name: 'BAT_DATA_OA_CHARGING',
         unit: 'W',
@@ -3531,6 +3635,14 @@ const state_attr = {
     },
     'ENERGY.SULFAT_CHARGE_RUN': {
         name: 'SULFAT_CHARGE_RUN',
+        unit: '',
+        booltype: true,
+        datetype: false,
+        iptype: false,
+        multiply: 1
+    },
+    'ENERGY.SUPP_BATT_DIAG': {
+        name: 'SUPP_BATT_DIAG',
         unit: '',
         booltype: true,
         datetype: false,


### PR DESCRIPTION
Added missing attribute definitions for the following new States:

REPORT_TO_DEV: State attribute definition missing for: ENERGY.GUI_BAT_DATA_MIN_CELL_VOLTAGE, Val: 3248
REPORT_TO_DEV: State attribute definition missing for: ENERGY.GUI_BAT_DATA_MAX_CELL_VOLTAGE, Val: 3320
REPORT_TO_DEV: State attribute definition missing for: ENERGY.SUPP_BATT_DIAG, Val: 0

REPORT_TO_DEV: State attribute definition missing for: BMS.CELL_BALANCE_STATUS, Val: 0,0,0,0
REPORT_TO_DEV: State attribute definition missing for: BMS.CELL_TEMPERATURES_MODULE_D, Val: 26,28,29,25,27,30
REPORT_TO_DEV: State attribute definition missing for: BMS.CELL_TEMPERATURES_MODULE_C, Val: 26,27,29,26,27,29
REPORT_TO_DEV: State attribute definition missing for: BMS.CELL_TEMPERATURES_MODULE_B, Val: 22,24,27,23,24,27
REPORT_TO_DEV: State attribute definition missing for: BMS.CELL_TEMPERATURES_MODULE_A, Val: 22,23,27,23,25,28
REPORT_TO_DEV: State attribute definition missing for: BMS.CELL_VOLTAGES_MODULE_D, Val: 3257,3254,3248,3258,3261,3306,3304,3317,3318,3317,3317,3316,3318,3318
REPORT_TO_DEV: State attribute definition missing for: BMS.CELL_VOLTAGES_MODULE_C, Val: 3265,3259,3265,3261,3262,3307,3310,3305,3307,3303,3307,3306,3305,3306
REPORT_TO_DEV: State attribute definition missing for: BMS.CELL_VOLTAGES_MODULE_B, Val: 3261,3280,3256,3252,3255,3308,3310,3312,3312,3306,3305,3314,3307,3313
REPORT_TO_DEV: State attribute definition missing for: BMS.CELL_VOLTAGES_MODULE_A, Val: 3263,3257,3252,3251,3255,3310,3311,3317,3316,3316,3313,3316,3320,3310
REPORT_TO_DEV: State attribute definition missing for: BMS.BMS_STATUS, Val: 1
REPORT_TO_DEV: State attribute definition missing for: BMS.BMS_STATUS_TIMESTAMP, Val: 1650385938